### PR TITLE
fixes #1

### DIFF
--- a/GitDepend/Configuration/Build.cs
+++ b/GitDepend/Configuration/Build.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace GitDepend.Configuration
+{
+	public class Build
+	{
+		[JsonProperty("script")]
+		public string Script { get; set; }
+
+		#region Overrides of Object
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		public override string ToString()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented);
+		}
+
+		#endregion
+	}
+}

--- a/GitDepend/Configuration/Dependency.cs
+++ b/GitDepend/Configuration/Dependency.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace GitDepend.Configuration
+{
+	public class Dependency
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+		[JsonProperty("url")]
+		public string Url { get; set; }
+
+		[JsonProperty("dir")]
+		public string Directory { get; set; }
+
+		[JsonProperty("branch")]
+		public string Branch { get; set; }
+
+		#region Overrides of Object
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		public override string ToString()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented);
+		}
+
+		#endregion
+	}
+}

--- a/GitDepend/Configuration/GitDependFile.cs
+++ b/GitDepend/Configuration/GitDependFile.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace GitDepend.Configuration
+{
+	public class GitDependFile
+	{
+		private List<Dependency> _dependencies;
+		private Build _build;
+		private Packages _packages;
+
+		[JsonProperty("build")]
+		public Build Build => _build ?? (_build = new Build());
+
+		[JsonProperty("packages")]
+		public Packages Packages => _packages ?? (_packages = new Packages());
+
+		[JsonProperty("dependencies")]
+		public List<Dependency> Dependencies => _dependencies ?? (_dependencies = new List<Dependency>());
+
+		#region Overrides of Object
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		public override string ToString()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented);
+		}
+
+		#endregion
+
+		public static GitDependFile LoadFromDir(string directory, out string error)
+		{
+			var current = directory;
+			bool isGitRoot;
+			do
+			{
+				isGitRoot = Directory.GetDirectories(current, ".git").Any();
+
+				if (!isGitRoot)
+				{
+					current = Directory.GetParent(current).FullName;
+				}
+
+			} while (!string.IsNullOrEmpty(current) && !isGitRoot);
+			
+
+			if (isGitRoot)
+			{
+				var file = Path.Combine(directory, "GitDepend.json");
+
+				if (File.Exists(file))
+				{
+					try
+					{
+						var json = File.ReadAllText(file);
+						var gitDependFile = JsonConvert.DeserializeObject<GitDependFile>(json);
+						error = null;
+						return gitDependFile;
+					}
+					catch (Exception ex)
+					{
+						error = ex.Message;
+						Console.Error.WriteLine(ex.Message);
+						return null;
+					}
+				}
+				error = null;
+				return new GitDependFile();
+			}
+
+			error = "This is not a git repository";
+			return null;
+		}
+	}
+}

--- a/GitDepend/Configuration/Packages.cs
+++ b/GitDepend/Configuration/Packages.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace GitDepend.Configuration
+{
+	public class Packages
+	{
+		[JsonProperty("dir")]
+		public string Directory { get; set; }
+
+		#region Overrides of Object
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		public override string ToString()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented);
+		}
+
+		#endregion
+	}
+}

--- a/GitDepend/GitDepend.csproj
+++ b/GitDepend/GitDepend.csproj
@@ -33,6 +33,14 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=1.9.71.2, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.1.9.71\lib\net45\CommandLine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -43,11 +51,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Configuration\Build.cs" />
+    <Compile Include="Configuration\Dependency.cs" />
+    <Compile Include="Configuration\GitDependFile.cs" />
+    <Compile Include="Configuration\Packages.cs" />
+    <Compile Include="Options.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/GitDepend/Options.cs
+++ b/GitDepend/Options.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CommandLine;
+using CommandLine.Text;
+using Newtonsoft.Json;
+
+namespace GitDepend
+{
+	class Options
+	{
+		private static Options _default;
+		public static Options Default => _default ?? (_default = new Options());
+
+		private Options()
+		{
+			
+		}
+
+		[Option('d', "dir", Required = false, HelpText = "The directory to process. The current working directory will be used if this option is ignored.")]
+		public string Directory { get; set; }
+
+		[Option("showconfig", Required = false, HelpText = "Displays the full configuration file")]
+		public bool ShowConfig { get; set; }
+
+		[ParserState]
+		public IParserState LastParserState { get; set; }
+
+		[HelpOption]
+		public string GetUsage()
+		{
+			return HelpText.AutoBuild(this, (HelpText current) => HelpText.DefaultParsingErrorsHandler(this, current));
+		}
+
+		#region Overrides of Object
+
+		/// <summary>
+		/// Returns a string that represents the current object.
+		/// </summary>
+		/// <returns>
+		/// A string that represents the current object.
+		/// </returns>
+		public override string ToString()
+		{
+			return JsonConvert.SerializeObject(this, Formatting.Indented);
+		}
+
+		#endregion
+	}
+}

--- a/GitDepend/Program.cs
+++ b/GitDepend/Program.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.IO;
+using GitDepend.Configuration;
 
 namespace GitDepend
 {
@@ -10,8 +8,42 @@ namespace GitDepend
 	{
 		static void Main(string[] args)
 		{
-			Console.WriteLine("I'm just here to reserve the name!");
-			Console.WriteLine("Real Git Dependency management to come!");
+			if (!CommandLine.Parser.Default.ParseArguments(args, Options.Default))
+			{
+				return;
+			}
+
+			if (string.IsNullOrEmpty(Options.Default.Directory))
+			{
+				Options.Default.Directory = Environment.CurrentDirectory;
+			}
+			else
+			{
+				Options.Default.Directory = Path.GetFullPath(Options.Default.Directory);
+			}
+
+			string error;
+			var file = GitDependFile.LoadFromDir(Options.Default.Directory, out error);
+
+			if (file == null || !string.IsNullOrEmpty(error))
+			{
+				if (string.IsNullOrEmpty(error))
+				{
+					Console.Error.WriteLine("I'm not sure why, but I can't load the GitDepend.json file");
+					Environment.Exit(1);
+				}
+				else
+				{
+					Console.Error.WriteLine(error);
+					Environment.Exit(2);
+				}
+			}
+
+			if (Options.Default.ShowConfig)
+			{
+				Console.WriteLine(file);
+				return;
+			}
 		}
 	}
 }

--- a/GitDepend/packages.config
+++ b/GitDepend/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="CommandLineParser" version="1.9.71" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net461" />
+</packages>


### PR DESCRIPTION
Adds the ability to load a GitDepend.json file at the root of a git repository.

The repository directory is specified on the command line with the --dir option. If that option is not provided the current working directory is assumed.