### PR TITLE
issue #84 The update can target specified deps

### DIFF
--- a/GitDepend/CommandLine/UpdateSubOptions.cs
+++ b/GitDepend/CommandLine/UpdateSubOptions.cs
@@ -1,9 +1,12 @@
-﻿namespace GitDepend.CommandLine
+﻿using System.Collections.Generic;
+using CommandLine;
+
+namespace GitDepend.CommandLine
 {
     /// <summary>
     /// The options for the update verb
     /// </summary>
-    public class UpdateSubOptions : CommonSubOptions
+    public class UpdateSubOptions : NamedDependenciesOptions
     {
     }
 }

--- a/GitDepend/Commands/UpdateCommand.cs
+++ b/GitDepend/Commands/UpdateCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO.Abstractions;
+using System.Linq;
 using GitDepend.Busi;
 using GitDepend.CommandLine;
 using GitDepend.Visitors;
@@ -48,18 +49,26 @@ namespace GitDepend.Commands
                 return checkoutVisitor.ReturnCode;
             }
 
+            _console.WriteLine();
             _algorithm.Reset();
-            var buildAndUpdateVisitor = new BuildAndUpdateDependenciesVisitor();
+            var buildAndUpdateVisitor = new BuildAndUpdateDependenciesVisitor(_options.Dependencies);
             _algorithm.TraverseDependencies(buildAndUpdateVisitor, _options.Directory);
 
             if (buildAndUpdateVisitor.ReturnCode == ReturnCode.Success)
             {
-                _console.WriteLine("Updated packages: ");
-                foreach (var package in buildAndUpdateVisitor.UpdatedPackages)
+                if (buildAndUpdateVisitor.UpdatedPackages.Any())
                 {
-                    _console.WriteLine($"    {package}");
+                    _console.WriteLine("Updated packages: ");
+                    foreach (var package in buildAndUpdateVisitor.UpdatedPackages)
+                    {
+                        _console.WriteLine($"    {package}");
+                    }
+                    _console.WriteLine("Update complete!");
                 }
-                _console.WriteLine("Update complete!");
+                else
+                {
+                    _console.WriteLine("nothing was updated");
+                }
             }
 
             return buildAndUpdateVisitor.ReturnCode;

--- a/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
+++ b/GitDepend/Visitors/DependencyVisitorAlgorithm.cs
@@ -113,7 +113,6 @@ namespace GitDepend.Visitors
 
                 // Visit the project.
                 code = visitor.VisitProject(dir, config);
-                _console.WriteLine();
 
                 // If something went wrong visiting the project we are done.
                 if (code != ReturnCode.Success)


### PR DESCRIPTION
Why: The update command needs to be able to target a specific
dependency, or multiple dependencies.

This change addresses the need by:

* restricting the visitdependency and visitproject endpoints to the
specified dependencies.