### PR TITLE
issue #125 Adding documentation for update

### DIFF
--- a/docs/source/usage/update.rst
+++ b/docs/source/usage/update.rst
@@ -1,0 +1,8 @@
+update
+======
+
+.. code-block:: bash
+
+    This is used to update nuget packages across all dependencies. 
+    
+    Run the ``sync`` command if you get the error of dependencies not being on the correct branch.


### PR DESCRIPTION
Why:

* No documentation currently exists.

This change addresses the need by:

* Creating a documentation page and adding some instructions