### PR TITLE
issue #120 Adding documentation for config

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,4 +31,5 @@ Command Line Options
    :caption: Verbs:
 
    usage/branch
+   usage/config
    usage/checkout

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -1,0 +1,9 @@
+config
+======
+
+Shows the configuration that will be used by GitDepend.
+
+.. code-block:: bash
+
+    --dir    The directory to process. The current working directory will be used
+             if this option is ignored.


### PR DESCRIPTION
Why:

* No documentation currently exists

This change addresses the need by:

* Creating a documentation page and adding some instructions