### PR TITLE
issue #119 Adds documentation for the clone verb

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,5 +31,7 @@ Command Line Options
    :caption: Verbs:
 
    usage/branch
+   usage/clone
    usage/config
    usage/checkout
+   usage/update

--- a/docs/source/usage/clone.rst
+++ b/docs/source/usage/clone.rst
@@ -1,0 +1,9 @@
+clone
+=====
+
+Recursively clones all dependencies
+
+.. code-block:: bash
+
+      --dir    The directory to process. The current working directory will be used
+               if this option is ignored.

--- a/docs/source/usage/update.rst
+++ b/docs/source/usage/update.rst
@@ -1,8 +1,11 @@
 update
 ======
 
+This is used to update nuget packages across all dependencies. 
+    
+Run the ``sync`` command if you get the error of dependencies not being on the correct branch.
+
 .. code-block:: bash
 
-    This is used to update nuget packages across all dependencies. 
-    
-    Run the ``sync`` command if you get the error of dependencies not being on the correct branch.
+      --dir    The directory to process. The current working directory will be used
+               if this option is ignored.


### PR DESCRIPTION
Why:

* No documentation currently exists

This change addresses the need by:

* Adding a usage/clone.rst file with basic help