### PR TITLE
#124 Adding documentation for sync

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -31,3 +31,4 @@ Command Line Options
    :caption: Verbs:
 
    usage/branch
+   usage/sync

--- a/docs/source/usage/sync.rst
+++ b/docs/source/usage/sync.rst
@@ -1,0 +1,12 @@
+sync
+======
+
+.. code-block:: bash
+
+    Sync will make sure that your current directory and dependencies are on the same branch.
+
+    If they are, nothing will be updated.
+    If your branches are out of sync, you will have a few options to resolve:
+        1. Resolve the differences in your GitDepend config files.
+        2. Assume config is correct, and switch to that branch.
+        3. Abort and take care of it yourself.

--- a/docs/source/usage/sync.rst
+++ b/docs/source/usage/sync.rst
@@ -1,8 +1,6 @@
 sync
 ======
 
-.. code-block:: bash
-
     Sync will make sure that your current directory and dependencies are on the same branch.
 
     If they are, nothing will be updated.


### PR DESCRIPTION
Why:

* No documentation exists.

This change addresses the need by:

* Creating documentation