### PR TITLE
issue #123 Status verb documentation

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -36,3 +36,4 @@ Command Line Options
    usage/checkout
    usage/init
    usage/update
+   usage/status

--- a/docs/source/usage/status.rst
+++ b/docs/source/usage/status.rst
@@ -1,8 +1,6 @@
 status
 ======
 
-.. code-block:: bash
-
     This displays the status of all the dependencies which you have listed in your config files.
     
     Basically, the same as you running ``git status`` in all of your directories.

--- a/docs/source/usage/status.rst
+++ b/docs/source/usage/status.rst
@@ -1,0 +1,8 @@
+status
+======
+
+.. code-block:: bash
+
+    This displays the status of all the dependencies which you have listed in your config files.
+    
+    Basically, the same as you running ``git status`` in all of your directories.


### PR DESCRIPTION
Why:

* No documentation existed

This change addresses the need by:

* Adding documentation in usage/status.rst