### PR TITLE
issue #143 adds make install as a target

### DIFF
--- a/GitDepend.UnitTests/Properties/AssemblyInfo.cs
+++ b/GitDepend.UnitTests/Properties/AssemblyInfo.cs
@@ -31,8 +31,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
-
-[assembly: AssemblyInformationalVersion("0.4.0-alpha0044")]
+// [assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/GitDepend/Properties/AssemblyInfo.cs
+++ b/GitDepend/Properties/AssemblyInfo.cs
@@ -30,8 +30,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyVersion("0.4.0.0")]
-[assembly: AssemblyFileVersion("0.4.0.0")]
-
-[assembly: AssemblyInformationalVersion("0.4.0-alpha0044")]
+// [assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,13 @@ goto :eof
 
     @echo ##teamcity[blockClosed name='Generate NuGet Packages (Debug)']
 
+install: package-debug
+    @call <<install.bat
+@echo off
+set /p VERSION= < version.txt
+choco install GitDepend.Portable -version %VERSION% -y -pre --force --allow-downgrade -source artifacts\Chocolatey\Debug
+<<
+
 build-release: version restore
     @echo ##teamcity[blockOpened name='Build Solution (Release)']
     @echo ##teamcity[compilationStarted compiler='MSBuild']

--- a/make.bat
+++ b/make.bat
@@ -18,7 +18,8 @@ if /i "%1%" == "" (
     goto :NMAKE
 ) else if /i "%1%" == "clean" (
     goto :NMAKE
-)
+) else if /i "%1%" == "install" (
+    goto :NMAKE
 ) else (
     goto :SHOW_USAGE
 )
@@ -49,3 +50,4 @@ echo                 and captures coverage information
 echo   teamcity    : Runs the full build (same as all) but does not generate
 echo                 html reports
 echo   clean       : Cleans the build
+echo   install     : Builds and installs the latest chocolatey package.


### PR DESCRIPTION
Why:

* I would like a way to quickly install the latest chocolatey package

This change addresses the need by:

* Adds an install target in the Makefile that depends on package-debug that will install the latest chocolatey package.