### PR TITLE
issue #138 Adds a unit test for incorrect status

### DIFF
--- a/GitDepend.UnitTests/Visitors/DisplayStatusVisitorTests.cs
+++ b/GitDepend.UnitTests/Visitors/DisplayStatusVisitorTests.cs
@@ -51,10 +51,15 @@ namespace GitDepend.UnitTests.Visitors
         [Test]
         public void VisitDependency_ShouldReturn_Success_WhenGitStatusSucceeds()
         {
+            RegisterMockFileSystem();
             var git = Container.Resolve<IGit>();
 
             git.Arrange(g => g.Status())
-                .Returns(ReturnCode.Success);
+                .Returns(() =>
+                {
+                    Assert.AreEqual(Lib1Directory, git.WorkingDirectory, "Invalid working directory");
+                    return ReturnCode.Success;
+                });
 
             IList<string> whilelist = new List<string>();
             var instance = new DisplayStatusVisitor(whilelist);


### PR DESCRIPTION
Why:

* There were no unit tests that caught #138

This change addresses the need by:

* Adding a unit test that verifies the working directory for the git
operation while doing a status check